### PR TITLE
Add Relion Platinum as supported device

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,2 +1,3 @@
 vendor_0x173a_device_0x21d5 1 # roche accu-Chek model  929
 vendor_0x173a_device_0x21d7 1 # some other similar model with product id 0x21d7 that should also work with this code
+vendor_0x173a_device_0x21d8 1 # Roche Relion Platinum model 982


### PR DESCRIPTION
Worked first try when adding this device; it appears to be nearly identical to the other meters (the linked driver supports it as well).